### PR TITLE
Changed requirement of socket-react to equal/greater than 0.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3",
         "react/event-loop": "0.3.*",
         "react/promise": "~1.0",
-        "clue/socket-react": "0.2.*",
+        "clue/socket-react": ">=0.2",
         "e-butik/iodophor": "1.*"
     },
     "autoload": {


### PR DESCRIPTION
In our project many repositories require igorw/evenement 2._, but socket-react 0.2._ accepts only igorw/evenement 1.*

I've updated the requirements to >=0.2 and tested the example 'ping.php' with success. 
